### PR TITLE
Fix a race condition in journal_write

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,4 @@
-rrdtool (1.99.0-1) unstable; urgency=medium
+rrdtool (1.99.0-2) unstable; urgency=medium
 
   * Add custom TrueNAS patches
 

--- a/fix-race-condition-in-joutnal_write.patch
+++ b/fix-race-condition-in-joutnal_write.patch
@@ -1,0 +1,19 @@
+diff --git a/src/rrd_daemon.c b/src/rrd_daemon.c
+index 3ad3a66f..cf125476 100644
+--- a/src/rrd_daemon.c
++++ b/src/rrd_daemon.c
+@@ -3412,10 +3412,12 @@ static int journal_write(
+ {                       /* {{{ */
+     int       chars;
+ 
+-    if (journal_fh == NULL)
++    pthread_mutex_lock(&journal_lock);
++    if (journal_fh == NULL) {
++        pthread_mutex_unlock(&journal_lock);
+         return 0;
++    }
+ 
+-    pthread_mutex_lock(&journal_lock);
+     chars = fprintf(journal_fh, "%s %s\n", cmd, args);
+     journal_size += chars;
+ 

--- a/pull.sh
+++ b/pull.sh
@@ -13,4 +13,7 @@ rm rrdtool_$VERSION.orig.tar.gz
 cp remove-corrupted-rrd-files.patch debian/patches
 echo 'remove-corrupted-rrd-files.patch' >> debian/patches/series
 
+cp fix-race-condition-in-joutnal_write.patch debian/patches
+echo 'fix-race-condition-in-joutnal_write.patch' >> debian/patches/series
+
 echo -e "$(cat changelog)\n\n$(cat debian/changelog)" > debian/changelog


### PR DESCRIPTION
There is a race condition in journal_write() where journal_lock is
being acquired after checking whether journal_fh is NULL or not.
journal_fh is a static file handle that can be set to NULL by any
other thread, while current thread is blocked by
pthread_mutex_lock(). This commit fixes this race condition.
